### PR TITLE
Update CircleCI config to use date-based image tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,10 @@ jobs:
     executor: aws-ecr/default
     steps:
       - checkout
+      - run:
+          name: Generate image tag
+          command: |
+            echo "export IMAGE_TAG=$(date +%m%d)-$(git rev-list --count HEAD)" >> $BASH_ENV
       - aws-ecr/build-and-push-image:
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
@@ -59,7 +63,7 @@ jobs:
           repo: ${REPO_NAME}
           dockerfile: Dockerfile
           path: .
-          tag: ${CIRCLE_TAG:-latest}  # use the CIRCLE_TAG for the Docker image tag, or 'latest' if it does not exist
+          tag: ${CIRCLE_TAG:-${IMAGE_TAG}} # use the CIRCLE_TAG for the Docker image tag, or the generated IMAGE_TAG if it does not exist
 
 workflows:
   build_and_test_and_push_image:


### PR DESCRIPTION
- Add a step to generate an image tag based on date and commit count.
- Replace 'latest' tag with the generated IMAGE_TAG if CIRCLE_TAG does not exist.