### PR TITLE
Remove requires from build-and-push-image job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,6 @@ workflows:
     jobs:
       - build-and-test
       - build-and-push-image:
-          requires:
-            - build-and-test
           filters:
             branches:
               only: main  # run this job for updates on main branch


### PR DESCRIPTION
- Removed the dependency on build-and-test job.
- build-and-push-image job will now run independently.