### PR TITLE
Add trailingSlash option to next.config.js

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -7,6 +7,7 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  trailingSlash: true,
   webpack: (config, { isServer }) => {
     if (isServer) {
       config.node = {


### PR DESCRIPTION
- The trailingSlash option has been added to the next.config.js file.
- This change will ensure that the exported pages do not include the .html extension.
![d9dd7aa3-1342-4355-8916-408eef726758](https://github.com/devchat-ai/devchat-webapp/assets/18692628/b36c6c6a-5d6a-4758-86fa-3c76b7f9dc42)
![img_v2_572a0cfc-6403-4b2b-ac4b-92d210421a9g](https://github.com/devchat-ai/devchat-webapp/assets/18692628/47f5999f-e61e-48b3-a51c-c7bdfa795f11)
